### PR TITLE
fix wildcard cases

### DIFF
--- a/src/wildcard/pattern/remove_contigus_slash.c
+++ b/src/wildcard/pattern/remove_contigus_slash.c
@@ -6,7 +6,7 @@
 /*   By: lespenel <lespenel@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/15 03:25:09 by lespenel          #+#    #+#             */
-/*   Updated: 2024/04/15 09:16:11 by lespenel         ###   ########.fr       */
+/*   Updated: 2024/04/15 09:48:03 by lespenel         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,10 +110,10 @@ static int	look_for_split_words(t_lexer *lexer)
 		{
 			tmp = ft_strjoin(curr->content, curr2->content);
 			free(curr->content);
-			free(curr2->content);
+			curr->content = tmp;
 			if (tmp == NULL)
 				return (-1);
-			curr->content = tmp;
+			free(curr2->content);
 			remove_vector(lexer, i + 1);
 			--i;
 		}


### PR DESCRIPTION
- echo */////"//"b'i''n'/ would previously match include/builtins/ src/builtins/ due to word split in quote (now it doesent)
- echo /*/"///"'/'"b"i"n"*/ would match to much file due to the same previous case
- echo ../*/.."/"/../ now matches that was not the case due to / split in quote

All theses cases were caused by the splitting of the quotes so */'b'"i"'n'/ will create a pattern like this:
*
/
b
i
n
/ (this will causes "builtins" to be matched) wich is obviously dramatical
and now its :
*
/bin/
wich is the correct pattern to send to the matching functions !
